### PR TITLE
Update instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the material for the [UCL Festival of Digital Research 
 > [!NOTE]
 > This is our recommended option, as you will more easily be able to keep playing with the notebook afterwards.
 
-Clone this repository (make sure to [install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)) and then enter inside the new directory by running the following commands in a terminal:
+Clone this repository (make sure to [install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)) and then enter inside the new directory by running the following commands in a terminal (we recommend using [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/overview?view=powershell-7.4) if on Windows):
 
 ```sh
 git clone https://github.com/UCL-ARC/julia-workshop
@@ -17,11 +17,11 @@ cd julia-workshop
 ```
 
 After [installing Julia](https://julialang.org/downloads/), start it with
-```
+```sh
 julia --project=.
 ```
 
-and then inside the Julia REPL you can run the notebook with
+and then inside the Julia [REPL](https://en.wikipedia.org/wiki/Read%E2%80%93eval%E2%80%93print_loop) you can run [Pluto](https://plutojl.org/), the interactive notebook environment we will be using, with
 
 ```julia
 # Necessary only the first time, to instantiate the environment
@@ -33,21 +33,42 @@ using Pluto
 Pluto.run()
 ```
 
+This should open a tab in your default browser showing the Pluto interface. From there find the `Open a notebook` section and click on the `Enter path or URL...` field and select `notebook.jl` from the drop-down and then click the `Open` button to open the example notebook we will be using.
+
+> [!NOTE]
+> The notebook will initially be opened in _Safe preview_ mode which allows you to view and edit the notebook content but not run any code, or view the rendered outputs. This is a security measure to prevent malicious notebooks being run automatically that may try to steal data. To exit from _Safe preview_ mode either click the _Safe preview ⓘ_ information button at the bottom of the interface and click `run this notebook` or click on the `Run notebook code` link in the top-right of the interface.
+
 ### Using a Docker container
 
 We also provide a [Docker image](https://github.com/UCL-ARC/julia-workshop/pkgs/container/julia-workshop) (built for `linux/amd64` and `linux/arm64`) for running the notebook, which you can pull with
 
-```
+```sh
 docker pull ghcr.io/ucl-arc/julia-workshop:main
 ```
 
-and then run the notebook with
+and then run [Pluto](https://plutojl.org/), the interactive notebook environment we will be using, with (if on MacOS or Linux)
 
-```
+```sh
 docker run -p 1234:1234 -ti ghcr.io/ucl-arc/julia-workshop:main julia -e 'using Pluto; Pluto.run(; host="0.0.0.0", port=1234)'
 ```
 
-You will need to load the notebook saved at `/root/notebook.jl`.
+or if using PowerShell on Windows run
+
+```PowerShell
+docker run -p 1234:1234 -ti ghcr.io/ucl-arc/julia-workshop:main julia -e 'using Pluto; Pluto.run(; host=""""0.0.0.0"""", port=1234)'
+```
+
+This will launch Pluto within the container, and if successful you should see a message similar to
+
+```
+[ Info: Loading...
+┌ Info:
+└ Go to http://0.0.0.0:1234/?secret=hgY7as1X in your browser to start writing ~ have fun!
+```
+
+where `hgY7as1X` in the URL will be replaced with another random alphanumeric string. The Pluto notebook environment is accessed as a web app, so you should open a browser window and navigate to the URL indicated in the message to open the Pluto interface. If you get `Unable to connect` message or similar when trying to open the URL, you may need to replace the `0.0.0.0` component with `localhost`, so for the example above you would navigate to `http://localhost:1234/?secret=hgY7as1X`. 
+
+Once you have the Pluto interface open in your browse,u will need to load the notebook saved at `/root/notebook.jl`, to open the notebook, find the `Open a notebook` section in the Pluto interface and click on the `Enter path or URL...` field and select `root/` and then `notebook.jl` from the drop-down file naviagtor and then click the `Open` button to open the example notebook we will be using.
 
 ### GitHub Codespaces
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This will launch Pluto within the container, and if successful you should see a 
 
 where `hgY7as1X` in the URL will be replaced with another random alphanumeric string. The Pluto notebook environment is accessed as a web app, so you should open a browser window and navigate to the URL indicated in the message to open the Pluto interface. If you get `Unable to connect` message or similar when trying to open the URL, you may need to replace the `0.0.0.0` component with `localhost`, so for the example above you would navigate to `http://localhost:1234/?secret=hgY7as1X`. 
 
-Once you have the Pluto interface open in your browse, you will need to load the notebook saved at `/root/notebook.jl`, to open the notebook, find the `Open a notebook` section in the Pluto interface and click on the `Enter path or URL...` field and select `root/` and then `notebook.jl` from the drop-down file naviagtor and then click the `Open` button to open the example notebook we will be using.
+Once you have the Pluto interface open in your browser, you will need to load the notebook saved at `/root/notebook.jl`, to open the notebook, find the `Open a notebook` section in the Pluto interface and click on the `Enter path or URL...` field and select `root/` and then `notebook.jl` from the drop-down file naviagtor and then click the `Open` button to open the example notebook we will be using.
 
 ### GitHub Codespaces
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This will launch Pluto within the container, and if successful you should see a 
 
 where `hgY7as1X` in the URL will be replaced with another random alphanumeric string. The Pluto notebook environment is accessed as a web app, so you should open a browser window and navigate to the URL indicated in the message to open the Pluto interface. If you get `Unable to connect` message or similar when trying to open the URL, you may need to replace the `0.0.0.0` component with `localhost`, so for the example above you would navigate to `http://localhost:1234/?secret=hgY7as1X`. 
 
-Once you have the Pluto interface open in your browse,u will need to load the notebook saved at `/root/notebook.jl`, to open the notebook, find the `Open a notebook` section in the Pluto interface and click on the `Enter path or URL...` field and select `root/` and then `notebook.jl` from the drop-down file naviagtor and then click the `Open` button to open the example notebook we will be using.
+Once you have the Pluto interface open in your browse, you will need to load the notebook saved at `/root/notebook.jl`, to open the notebook, find the `Open a notebook` section in the Pluto interface and click on the `Enter path or URL...` field and select `root/` and then `notebook.jl` from the drop-down file naviagtor and then click the `Open` button to open the example notebook we will be using.
 
 ### GitHub Codespaces
 


### PR DESCRIPTION
Adds
- explanations of how to open notebook within Pluto interface for both local and Docker routes,
- some Windows specific details (see https://github.com/UCL-ARC/julia-workshop/issues/2#issuecomment-2151744949),
- note on _Safe preview_ mode in Pluto and how to exit,
- how to open Pluto interface in browser if using Docker route (as for me at least it doesn't automatically open in either Windows or Ubuntu in this case),
- some other minor expansions and clarifications.