### PR TITLE
Update project/notebook environments + Docker image to use Julia v1.10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM julia:1.10.3
+FROM julia:1.10.4
 
 # Install git
 RUN /bin/sh -c 'export DEBIAN_FRONTEND=noninteractive \

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -215,9 +215,9 @@ version = "1.4.3"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "3da7367955dcc5c54c1ba4d402ccdc09a1a3e046"
+git-tree-sha1 = "a028ee3cb5641cccc4c24e90c36b0a4f7707bdf5"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.13+1"
+version = "3.0.14+0"
 
 [[deps.OrderedCollections]]
 git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.3"
+julia_version = "1.10.4"
 manifest_format = "2.0"
 project_hash = "0facbe7d5b2efb15a9566d7eab560798f34ed819"
 

--- a/notebook.jl
+++ b/notebook.jl
@@ -576,7 +576,7 @@ julia = "~1.10"
 PLUTO_MANIFEST_TOML_CONTENTS = """
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.3"
+julia_version = "1.10.4"
 manifest_format = "2.0"
 project_hash = "6749f9a5cd4403655db8bacf5503f28bb125e022"
 

--- a/notebook.jl
+++ b/notebook.jl
@@ -610,9 +610,9 @@ version = "1.1.1"
 
 [[deps.ArrayInterface]]
 deps = ["Adapt", "LinearAlgebra", "SparseArrays", "SuiteSparse"]
-git-tree-sha1 = "133a240faec6e074e07c31ee75619c90544179cf"
+git-tree-sha1 = "ed2ec3c9b483842ae59cd273834e5b46206d6dda"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.10.0"
+version = "7.11.0"
 
     [deps.ArrayInterface.extensions]
     ArrayInterfaceBandedMatricesExt = "BandedMatrices"
@@ -1365,9 +1365,9 @@ version = "1.4.3"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "3da7367955dcc5c54c1ba4d402ccdc09a1a3e046"
+git-tree-sha1 = "a028ee3cb5641cccc4c24e90c36b0a4f7707bdf5"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.13+1"
+version = "3.0.14+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -1674,9 +1674,9 @@ version = "2.4.0"
     ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 
 [[deps.StaticArraysCore]]
-git-tree-sha1 = "36b3d696ce6366023a0ea192b4cd442268995a0d"
+git-tree-sha1 = "192954ef1208c7019899fbf8049e717f92959682"
 uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-version = "1.4.2"
+version = "1.4.3"
 
 [[deps.Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]


### PR DESCRIPTION
I think should resolve #3 if I've followed instructions correctly.

Julia v1.10.4 is [now released](https://julialang.org/downloads/#current_stable_release) and there is also a [corresponding Docker image available](https://hub.docker.com/_/julia/).

Activating the `julia-workshop` environment in Julia v1.10.4 and running the commands @giordano [suggested ](https://github.com/UCL-ARC/julia-workshop/issues/3#issue-2328012265)

```Julia
using Pkg
Pkg.instantiate()
using Pluto
Pluto.activate_notebook_environment("notebook.jl")
Pkg.instantiate()
```

worked but didn't actually change anything locally for me.

Running instead

```Julia
using Pkg
Pkg.resolve()
using Pluto
Pluto.activate_notebook_environment("notebook.jl")
Pkg.resolve()
```

however does change both `Manifest.toml` and `notebook.jl` despite confusingly both `Pkg.resolve()` calls outputing messages of the form

```
  No Changes to `...Project.toml`
  No Changes to `...Manifest.toml`
```

The changes here correspond to the differences from running the second `resolve` variant of the snippets above and manually editing the version tag in the Dockerfile. I didn't touch the Julia version specifier in the `compat` section of `Project.toml` as my understanding from [these docs](https://pkgdocs.julialang.org/v1/compatibility/) is that a version specifier of "1.10.3" would still indicate compatibility with v1.10.4.